### PR TITLE
Adds Text Domain for future i11n. Also matches WP.org plugin slug

### DIFF
--- a/elasticpress.php
+++ b/elasticpress.php
@@ -6,6 +6,7 @@
  * Version:     1.5.0
  * Author:      Aaron Holbrook, Taylor Lovett, Matt Gross, 10up, Christopher Goldman, DHAP Digital, Inc.
  * Author URI:  http://wpengine.com/
+ * Text Domain: wpengine-search
  * License:     GPLv2 or later
  *
  * This is a fork of https://github.com/10up/ElasticPress


### PR DESCRIPTION
Fixing @stevenkword’s merge conflicts… ;)
