### PR TITLE
Switch the package name to differentiate from the 10up plugin.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "10up/ElasticPress",
+  "name": "wpengine/wpe-search",
   "description": "Integrate Elasticsearch with WordPress.",
   "type": "wordpress-plugin",
   "keywords": ["wordpress", "plugin", "elasticsearch", "elasticpress", "search"],


### PR DESCRIPTION
Composer installs the plugin into a directory named using the project name (in this case `ElasticPress`). To install into a directory named `wpe-search`, this PR changes the name property to the WP Engine organization and project name.
